### PR TITLE
JobState: Add support for a nullary .end method

### DIFF
--- a/src/main/kotlin/JobState.kt
+++ b/src/main/kotlin/JobState.kt
@@ -56,6 +56,7 @@ class JobState<U: Any> @PublishedApi internal constructor(val value: U?){
         return status
     }
 
+    @JvmName("endNullary")
     fun end(): JobStatus {
         this.status = JobStatus.Success
         return status

--- a/src/main/kotlin/JobState.kt
+++ b/src/main/kotlin/JobState.kt
@@ -56,6 +56,11 @@ class JobState<U: Any> @PublishedApi internal constructor(val value: U?){
         return status
     }
 
+    fun end(): JobStatus {
+        this.status = JobStatus.Success
+        return status
+    }
+
     inline fun process(newStatus: JobStatus, predicate: (U) -> Boolean): JobState<U> {
         if(inProgress() && !predicate(value!!))
             this.status = newStatus

--- a/src/test/kotlin/JobStateTest.kt
+++ b/src/test/kotlin/JobStateTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.experimental.runBlocking
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
 class JobStateTest {
@@ -162,6 +163,18 @@ class JobStateTest {
                 .end { it > 0 }
 
         assertEquals(JobStatus.PermanentFailure, result)
+    }
+
+    @Test
+    fun testNullaryEndIsSuccess() {
+        val res = jobOne.asPipe().end()
+        assertEquals(JobStatus.Success, res)
+    }
+
+    @Test
+    fun testNullaryEndNonSuccess() {
+        val res = jobOne.asPipe().require { false }.end()
+        assertNotEquals(JobStatus.Success, res)
     }
 
     private suspend fun lolz() = 10


### PR DESCRIPTION
The nullary end method is equivalent to calling .end with a function
that constantly returns true. In main usecases getting all the way to
end makes success to only possibility, hence to avoid calling it with
a dummy function a nullary option is introduced.