### PR TITLE
Expose Kafka's offset field to the user

### DIFF
--- a/src/main/kotlin/Message.kt
+++ b/src/main/kotlin/Message.kt
@@ -1,6 +1,7 @@
 package franz
 
 interface Message<out K, out V> {
+    fun offset(): Long
     fun value() : V
     fun headers(): Array<Pair<String, ByteArray>>
     fun headers(key: String): Array<ByteArray>

--- a/src/main/kotlin/engine/kafka_one/KafkaMessage.kt
+++ b/src/main/kotlin/engine/kafka_one/KafkaMessage.kt
@@ -4,6 +4,7 @@ import franz.Message
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 class KafkaMessage<T, U>(private val rec: ConsumerRecord<T, U>) : Message<T, U> {
+    override fun offset(): Long = rec.offset()
     override fun value(): U = rec.value()
     override fun key(): T = rec.key()
     override fun headers(): Array<Pair<String, ByteArray>> = rec.headers()

--- a/src/test/kotlin/JobStateTest.kt
+++ b/src/test/kotlin/JobStateTest.kt
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test
 import kotlin.test.*
 
 class TestMessage<T>(private val value: T) : Message<String, T> {
+    override fun offset(): Long {
+        TODO("not implemented")
+    }
     override fun value(): T = value
     override fun headers(): Array<Pair<String, ByteArray>> {
         throw NotImplementedError()


### PR DESCRIPTION
The offset field is really useful for use as a per-key ordering key. The timestamp is not guaranteed to be 1) unique or 2) A user may in provide their own timestamp which has no guarantees.