### PR TITLE
Allow setting Kafka headers when producing messages

### DIFF
--- a/src/main/kotlin/producer/Producer.kt
+++ b/src/main/kotlin/producer/Producer.kt
@@ -6,11 +6,17 @@ import kotlinx.coroutines.experimental.future.await
 
 typealias ProduceResultF = CompletableFuture<ProduceResult>
 
+
+
 interface Producer<K, V> {
     @Deprecated("This API relies on directly on Kafka and will be removed")
     fun sendRaw(rec: ProducerRecord<K, V>): ProduceResultF
     fun sendAsync(topic: String, key: K?, value: V): ProduceResultF
-    fun close() : Unit
+
+    fun sendAsync(topic: String, key: K?, value: V, headers: Iterable<Pair<String, ByteArray>>) : ProduceResultF
+    fun sendAsync(topic: String, key: K?, value: V, headers: Map<String, ByteArray>) =
+        sendAsync(topic, key, value, headers.toList())
+    fun close(): Unit
 
     fun sendAsync(topic: String, value: V): ProduceResultF =
         sendAsync(topic, null, value)
@@ -20,4 +26,11 @@ interface Producer<K, V> {
         sendAsync(topic, key, value).await()
     suspend fun send(topic: String, value: V): ProduceResult =
         sendAsync(topic, value).await()
+
+
+    suspend fun send(topic: String, key: K?, value: V, headers: Iterable<Pair<String, ByteArray>>) =
+        sendAsync(topic, key, value, headers).await()
+
+    suspend fun send(topic: String, key: K?, value: V, headers: Map<String, ByteArray>) =
+        sendAsync(topic, key, value, headers).await()
 }

--- a/src/main/kotlin/producer/kafka_one/KProducer.kt
+++ b/src/main/kotlin/producer/kafka_one/KProducer.kt
@@ -4,15 +4,23 @@ import franz.producer.ProduceResultF
 import franz.producer.Producer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.internals.RecordHeader
 
-class KProducer<K, V> internal constructor(private val producer: KafkaProducer<K, V>) : Producer<K, V> {
+private fun pairToHeader(p: Pair<String, ByteArray>) =
+    RecordHeader(p.first, p.second)
+
+class KProducer<K, V> internal constructor(private val producer: KafkaProducer<K?, V>) : Producer<K, V> {
     internal constructor(opts: Map<String, Any>): this(makeProducer(opts))
-    private fun doSend(rec: ProducerRecord<K, V>) =
+    private fun doSend(rec: ProducerRecord<K?, V>) =
         producer.sendAsync(rec).thenApply { KProduceResult.create(it) }
     override fun sendAsync(topic: String, key: K?, value: V): ProduceResultF =
-        doSend(ProducerRecord<K, V>(topic, key, value))
+        doSend(ProducerRecord(topic, key, value))
     override fun sendRaw(rec: ProducerRecord<K, V>) =
-        doSend(rec)
+        doSend(rec as ProducerRecord<K?, V>) // This is fine because K :: K? for all K
     override fun close() =
         producer.close()
+
+    override fun sendAsync(topic: String, key: K?, value: V, headers: Iterable<Pair<String, ByteArray>>): ProduceResultF =
+        doSend(ProducerRecord(topic, null, key, value, headers.map(::pairToHeader)))
+
 }

--- a/src/main/kotlin/producer/mock/MockProducer.kt
+++ b/src/main/kotlin/producer/mock/MockProducer.kt
@@ -31,6 +31,11 @@ class MockProducer<K, V>(
         onSendRaw.invoke(rec.value())
         return supplyAsync { sendRawResult }
     }
+
+    override fun sendAsync(topic: String, key: K?, value: V, headers: Iterable<Pair<String, ByteArray>>): ProduceResultF {
+        onSendAsync.invoke(value)
+        return supplyAsync { sendAsyncResult }
+    }
     override fun close() = Unit
 
     fun createFactory() =


### PR DESCRIPTION
When we added support for reading Kafka headers in Consumers we forgot to do the same for Producers. So I went ahead and added those.

Some of the changes have to do with how nullable types are treated when keys are missing.