### PR TITLE
Add send methods with headers for TopicProducers

### DIFF
--- a/src/main/kotlin/producer/TopicProducer.kt
+++ b/src/main/kotlin/producer/TopicProducer.kt
@@ -6,8 +6,12 @@ class TopicProducer<in K, in V> internal constructor(
 
     fun sendAsync(key: K, value: V) = producer.sendAsync(topic, key, value)
     fun sendAsync(value: V) = producer.sendAsync(topic, value)
+    fun sendAsync(key: K?, value: V, headers: Map<String, ByteArray>) =
+        producer.sendAsync(topic, key, value, headers)
 
     suspend fun send(key: K?, value: V) = producer.send(topic, key, value)
     suspend fun send(value: V) = producer.send(topic, value)
+    suspend fun send(key: K?, value: V, headers: Map<String, ByteArray>) =
+        producer.send(topic, key, value, headers)
 }
 


### PR DESCRIPTION
This makes the normal and topiced producer APIs symmetrical. At
present there is no way of setting headers with a topic producer, this
adds it.