### PR TITLE
[WIP] Fix (hopefully) issue with off-by-one error with committed offsets.

### DIFF
--- a/src/main/kotlin/engine/kafka_one/JobStatuses.kt
+++ b/src/main/kotlin/engine/kafka_one/JobStatuses.kt
@@ -17,7 +17,7 @@ private fun findCommittableOffsets(x: Map<JobId, JobStatus>) = x
         }
         .filterNotNull()
         .toMap()
-        .mapValues { (_, v) -> OffsetAndMetadata(v) }
+        .mapValues { (_, v) -> OffsetAndMetadata(v + 1) }
 
 data class JobStatuses<T, U>(
         private val jobStatuses: Map<JobId, JobStatus> = emptyMap<JobId, JobStatus>(),

--- a/src/main/kotlin/engine/kafka_one/KafkaConsumerActor.kt
+++ b/src/main/kotlin/engine/kafka_one/KafkaConsumerActor.kt
@@ -31,9 +31,7 @@ const val POLLING_INTERVAL = 30000L
 private fun <T, U> commitFinishedJobs(c: KafkaConsumer<T, U>,
                                       statuses: JobStatuses<T, U>)
     : JobStatuses<T, U> =
-    statuses.committableOffsets()
-        .mapValues { it.value.incrementOffset() }
-        .also {
+    statuses.committableOffsets().also {
         logger.info { "Pushing new offsets for ${it.count()} partitions" }
         c.commitAsync(it) { res, exc ->
             if (exc != null) {
@@ -43,9 +41,6 @@ private fun <T, U> commitFinishedJobs(c: KafkaConsumer<T, U>,
     }.let {
         statuses.removeCommitted(it)
     }
-
-private fun OffsetAndMetadata.incrementOffset(): OffsetAndMetadata =
-    OffsetAndMetadata(this.offset() + 1, this.metadata())
 
 private fun <T, U> fetchMessagesFromKafka(c: KafkaConsumer<T, U>,
                                           outQueue: BlockingQueue<ConsumerRecord<T, U>>,

--- a/src/test/kotlin/JobStatusesTest.kt
+++ b/src/test/kotlin/JobStatusesTest.kt
@@ -90,7 +90,7 @@ class JobStatusesTest {
                     "The default partition should have a committable offset"
             )
             val offset = res!!.offset()
-            assertEquals(offset, CR1.offset(), "The offset of the Successful job should be comitted")
+            assertEquals(offset, CR1.offset() + 1, "The offset of the Successful job should be comitted")
         }
     }
     @Test
@@ -118,7 +118,7 @@ class JobStatusesTest {
             val res = it[DEFAULT_TOPIC_PARTITION]
             assertNotNull(res, "One partition should be committable")
             val offset = res!!.offset()
-            assertEquals(offset, CR1.offset())
+            assertEquals(offset, CR1.offset() + 1)
         }
     }
     @Test
@@ -129,7 +129,7 @@ class JobStatusesTest {
         )).committableOffsets().let {
             assertNull(it[DEFAULT_TOPIC_P2], "Partition 2 should not be committable")
             assertNotNull(it[DEFAULT_TOPIC_PARTITION], "Partition 1 should be committable")
-            assertEquals(CR1.offset(), it[DEFAULT_TOPIC_PARTITION]!!.offset(), "CR1 should be committable")
+            assertEquals(CR1.offset() + 1, it[DEFAULT_TOPIC_PARTITION]!!.offset(), "CR1 should be committable")
         }
     }
     @Test
@@ -140,7 +140,7 @@ class JobStatusesTest {
         )).committableOffsets().let {
             assertNull(it[DEFAULT_TOPIC_PARTITION], "Default topic partition should not be committable")
             assertNotNull(it[ALTERNATE_TOPIC_P1], "alternate topic, partition 1 should be committable")
-            assertEquals(OTHER_TOPIC_CR1.offset(),
+            assertEquals(OTHER_TOPIC_CR1.offset() + 1,
                     it[ALTERNATE_TOPIC_P1]!!.offset(), "OTHER_TOPIC_CR1 should be committable"
             )
         }


### PR DESCRIPTION
Documentation for Kafka function `commitAsync`
>Commit the specified offsets for the specified list of topics and partitions to Kafka.
This commits offsets to Kafka. The offsets committed using this API will be used on the first fetch after every rebalance and also on startup. As such, if you need to store offsets in anything other than Kafka, this API should not be used. **The committed offset should be the next message your application will consume, i.e. lastProcessedMessageOffset + 1.**
This is an asynchronous call and will not block. Any errors encountered are either passed to the callback (if provided) or discarded.

I believe this is not have we have done it until now, hence the repeated processing of messages when restarting a Franz worker. This pull requests fixes this issue.

I have not tested this yet, so I think we should wait with merging it until we have verified that this fixes the issue. I have not added any test cases to test that this works properly either, since I cannot see how this can be tested in a meaningful manner without actually using Kafka.