### PR TITLE
Migrate to stable coroutines API and Kotlin 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'description of project'
 defaultTasks 'run'
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.3.0'
     ext.jvm_version = '1.8'
     ext.junit_platform_version = '1.0.0-M4'
     repositories {
@@ -33,9 +33,9 @@ apply plugin: "org.junit.platform.gradle.plugin"
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:0.22.2'
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.22.2'
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.0.1'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1'
     compile 'io.github.microutils:kotlin-logging:1.4.6'
     compile 'org.apache.kafka:kafka-clients:0.11.0.0'
     runtime 'ch.qos.logback:logback-classic:1.2.3'

--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,6 @@ compileJava {
     options.encoding = 'UTF-8'
 }
 
-kotlin {
-    experimental {
-        coroutines 'enable'
-    }
-}
-
 // Important: All classes containing test cases must match the
 // the regex pattern "^.*Tests?$" to be picked up by the junit-gradle plugin.
 sourceSets {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,6 +1,6 @@
 package franz
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import java.util.*
 

--- a/src/main/kotlin/WorkerBuilder.kt
+++ b/src/main/kotlin/WorkerBuilder.kt
@@ -3,6 +3,8 @@ package franz
 import franz.engine.ConsumerActorFactory
 import franz.engine.WorkerFunction
 import franz.engine.kafka_one.KafkaConsumerActorFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 
 private val stringDeser = "org.apache.kafka.common.serialization.StringDeserializer"
 private val byteArrayDeser = "org.apache.kafka.common.serialization.ByteArrayDeserializer"
@@ -41,7 +43,7 @@ data class WorkerBuilder<T> private constructor(
 
     fun getInterceptors() = interceptors
 
-    fun start(){
+    fun start(scope: CoroutineScope = GlobalScope){
         val c = engine.create<String, T>(opts, topics)
         setupInterceptors()
         c.createWorker(fn!!)

--- a/src/main/kotlin/WorkerBuilder.kt
+++ b/src/main/kotlin/WorkerBuilder.kt
@@ -46,7 +46,7 @@ data class WorkerBuilder<T> private constructor(
     fun start(scope: CoroutineScope = GlobalScope){
         val c = engine.create<String, T>(opts, topics)
         setupInterceptors()
-        c.createWorker(fn!!)
+        c.createWorker(fn!!, scope)
         c.start()
     }
 

--- a/src/main/kotlin/engine/ConsumerActor.kt
+++ b/src/main/kotlin/engine/ConsumerActor.kt
@@ -2,6 +2,8 @@ package franz.engine
 
 import franz.JobStatus
 import franz.Message
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 
 typealias WorkerFunction<T, U> = suspend (Message<T, U>) -> JobStatus
 
@@ -10,5 +12,8 @@ interface ConsumerActor<T, U> {
     fun stop()
     fun subscribe(fn: (Message<T, U>) -> Unit)
     fun setJobStatus(msg: Message<T, U>, status: JobStatus)
-    fun createWorker(fn: WorkerFunction<T, U>)
+    fun createWorker(
+        fn: WorkerFunction<T, U>,
+        scope: CoroutineScope = GlobalScope
+    )
 }

--- a/src/main/kotlin/engine/kafka_one/KafkaConsumerActor.kt
+++ b/src/main/kotlin/engine/kafka_one/KafkaConsumerActor.kt
@@ -1,16 +1,16 @@
 package franz.engine.kafka_one
+
 import franz.JobStateException
 import franz.JobStatus
 import franz.Message
 import franz.engine.ConsumerActor
 import franz.engine.WorkerFunction
-import franz.log
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import mu.KotlinLogging
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
@@ -149,8 +149,11 @@ class KafkaConsumerActor<T, U>(private val kafkaConsumer: KafkaConsumer<T, U>) :
     override fun setJobStatus(message: Message<T, U>, status: JobStatus) =
         commandQueue.put(SetJobStatus((message as KafkaMessage).jobId(), status))
 
-    override fun createWorker(fn: WorkerFunction<T, U>){
-        Thread { worker(this, fn)}.start()
+    override fun createWorker(
+        fn: WorkerFunction<T, U>,
+        scope: CoroutineScope
+    ){
+        Thread { worker(this, fn, scope)}.start()
     }
 
     private inline fun tryJobStatus(fn: () -> JobStatus) = try {
@@ -163,10 +166,14 @@ class KafkaConsumerActor<T, U>(private val kafkaConsumer: KafkaConsumer<T, U>) :
         JobStatus.TransientFailure
     }
 
-    private fun <T, U> worker(consumer: ConsumerActor<T, U>, fn: WorkerFunction<T, U>){
+    private fun <T, U> worker(
+        consumer: ConsumerActor<T, U>,
+        fn: WorkerFunction<T, U>,
+        scope: CoroutineScope
+    ){
         try {
             consumer.subscribe {
-                launch(CommonPool) {
+                scope.launch(Dispatchers.Default) {
                     consumer.setJobStatus(it, tryJobStatus {
                         fn(it)
                     })

--- a/src/main/kotlin/engine/mock/MockConsumerBase.kt
+++ b/src/main/kotlin/engine/mock/MockConsumerBase.kt
@@ -5,6 +5,7 @@ import franz.JobStatus
 import franz.Message
 import franz.engine.ConsumerActor
 import franz.engine.WorkerFunction
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 
 abstract class MockConsumerActorBase<T, U> : ConsumerActor<T, U> {
@@ -30,7 +31,7 @@ abstract class MockConsumerActorBase<T, U> : ConsumerActor<T, U> {
         internalResults.add(Result(e, JobStatus.TransientFailure))
     }
 
-    override fun createWorker(fn: WorkerFunction<T, U>) {
+    override fun createWorker(fn: WorkerFunction<T, U>, scope: CoroutineScope) {
         worker(this, fn)
     }
 

--- a/src/main/kotlin/engine/mock/MockConsumerBase.kt
+++ b/src/main/kotlin/engine/mock/MockConsumerBase.kt
@@ -5,7 +5,7 @@ import franz.JobStatus
 import franz.Message
 import franz.engine.ConsumerActor
 import franz.engine.WorkerFunction
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 abstract class MockConsumerActorBase<T, U> : ConsumerActor<T, U> {
 

--- a/src/main/kotlin/producer/Producer.kt
+++ b/src/main/kotlin/producer/Producer.kt
@@ -2,7 +2,7 @@ package franz.producer
 
 import org.apache.kafka.clients.producer.ProducerRecord
 import java.util.concurrent.CompletableFuture
-import kotlinx.coroutines.experimental.future.await
+import kotlinx.coroutines.future.await
 
 typealias ProduceResultF = CompletableFuture<ProduceResult>
 

--- a/src/test/kotlin/BuildTest.kt
+++ b/src/test/kotlin/BuildTest.kt
@@ -1,6 +1,6 @@
 import franz.WorkerBuilder
 import franz.engine.mock.MockConsumerActor
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class BuildTest{

--- a/src/test/kotlin/JobStateTest.kt
+++ b/src/test/kotlin/JobStateTest.kt
@@ -1,6 +1,6 @@
 package franz
 
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import kotlin.test.*

--- a/src/test/kotlin/MockProducerTest.kt
+++ b/src/test/kotlin/MockProducerTest.kt
@@ -1,7 +1,7 @@
 import franz.*
 import franz.engine.mock.MockConsumerActor
 import franz.engine.mock.MockMessage
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/WorkerInterceptorTest.kt
+++ b/src/test/kotlin/WorkerInterceptorTest.kt
@@ -2,7 +2,7 @@ package franz
 
 import franz.engine.mock.MockConsumerActor
 import franz.engine.mock.MockMessage
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/WorkerTest.kt
+++ b/src/test/kotlin/WorkerTest.kt
@@ -1,7 +1,7 @@
 import franz.*
 import franz.engine.mock.MockConsumerActor
 import franz.engine.mock.MockMessage
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 


### PR DESCRIPTION
Use Kotlin coroutines 1.0.1 with stable API and Kotlin 1.3. Most important change is that functions such as `launch` and `async` must now be invoked from a `CoroutineScope`, which I have defaulted to GlobalScope when it is required. It can perhaps be debated if this is a sound solution. 

Also note that this has breaking API changes, both because of changes in our interfaces and because the underlying API incompatibility between experimental coroutines API and the stable coroutines API.