### PR TITLE
Do not store WorkerInterceptor(s) in a list

### DIFF
--- a/src/main/kotlin/WorkerInterceptor.kt
+++ b/src/main/kotlin/WorkerInterceptor.kt
@@ -4,13 +4,29 @@ typealias InterceptorStage = suspend(WorkerInterceptor, JobStatus) -> JobStatus
 
 open class WorkerInterceptor(
     var jobState: JobState<Any>? = null,
-    var next: WorkerInterceptor? = null,
+    val next: WorkerInterceptor? = null,
     val onIntercept: InterceptorStage = { interceptor, default ->
         interceptor.executeNext(default)
     }
 ){
     suspend fun executeNext(default: JobStatus): JobStatus {
-        val nextInterceptor = next
-        return nextInterceptor?.onIntercept?.invoke(nextInterceptor, default) ?: JobStatus.Success
+        val nextInterceptor: WorkerInterceptor = next ?: return JobStatus.Success
+        return nextInterceptor.onIntercept.invoke(nextInterceptor, default)
     }
+
+    fun <U: Any> setState(state: JobState<U>) {
+        this.jobState = state as? JobState<Any>
+        next?.setState(state)
+    }
+
+    open fun size(): Int = 1 + (next?.size() ?: 0)
+}
+
+fun WorkerInterceptor?.addInterceptor(next: WorkerInterceptor): WorkerInterceptor =
+    this?.next?.addInterceptor(next) ?: next
+
+internal object EmptyInterceptor: WorkerInterceptor(null, null, { _, _ -> JobStatus.Incomplete }) {
+    fun addInterceptor(next: WorkerInterceptor): WorkerInterceptor = next
+
+    override fun size(): Int = 0
 }

--- a/src/test/kotlin/JobStateTest.kt
+++ b/src/test/kotlin/JobStateTest.kt
@@ -31,9 +31,9 @@ class TestMessage<T>(private val value: T) : Message<String, T> {
 }
 
 class JobStateTest {
-    private fun <U> jobFrom(value: U): JobState<Message<String, U>> = JobState(TestMessage(value), Stack(), Stack(), emptyList())
+    private fun <U> jobFrom(value: U): JobState<Message<String, U>> = JobState(TestMessage(value), Stack(), Stack(), null)
     val jobOne = jobFrom("1")
-    val nullJob = JobState<Message<String, ByteArray>>(null, Stack(), Stack(), emptyList())
+    val nullJob = JobState<Message<String, ByteArray>>(null, Stack(), Stack(), null)
 
     @Test
     fun testCreateJobState() {

--- a/src/test/kotlin/MockProducerTest.kt
+++ b/src/test/kotlin/MockProducerTest.kt
@@ -25,7 +25,7 @@ class MockProducerTest {
             val mockConsumer = MockConsumerActor.ofString(listOf(getMockMessage("hai")))
 
             getMockWorker(mockConsumer) {
-                JobState("value", Stack(), Stack(), emptyList())
+                JobState("value", Stack(), Stack(), null)
                     .map { true }
                     .end()
             }.start()
@@ -42,7 +42,7 @@ class MockProducerTest {
             val mockConsumer = MockConsumerActor.ofString(listOf(getMockMessage("hai")))
 
             getMockWorker(mockConsumer) {
-                JobState("value", Stack(), Stack(), emptyList())
+                JobState("value", Stack(), Stack(), null)
                     .sideEffect{ println("Im running")}
                     .map { throw DummyException() }
                     .end()
@@ -60,7 +60,7 @@ class MockProducerTest {
             val mockConsumer = MockConsumerActor.ofString(listOf(getMockMessage("hai")))
 
             getMockWorker(mockConsumer) {
-                JobState("value", Stack(), Stack(), emptyList())
+                JobState("value", Stack(), Stack(), null)
                     .mapRequire { true }
                     .end()
             }.start()
@@ -77,7 +77,7 @@ class MockProducerTest {
             val mockConsumer = MockConsumerActor.ofString(listOf(getMockMessage("hai")))
 
             getMockWorker(mockConsumer) {
-                JobState("value", Stack(), Stack(), emptyList())
+                JobState("value", Stack(), Stack(), null)
                     .mapRequire { throw DummyException() }
                     .end()
             }.start()

--- a/src/test/kotlin/WorkerInterceptorTest.kt
+++ b/src/test/kotlin/WorkerInterceptorTest.kt
@@ -29,7 +29,7 @@ class WorkerInterceptorTest {
                     }
 
 
-            assertEquals(0, worker.getInterceptors().size)
+            assertEquals(0, worker.getInterceptors().size())
         }
     }
 
@@ -50,7 +50,7 @@ class WorkerInterceptorTest {
 
                     }
 
-            assertEquals(1, worker.getInterceptors().size)
+            assertEquals(1, worker.getInterceptors().size())
         }
     }
 
@@ -71,7 +71,7 @@ class WorkerInterceptorTest {
 
                     }
 
-            assertEquals(3, worker.getInterceptors().size)
+            assertEquals(3, worker.getInterceptors().size())
         }
     }
 
@@ -91,7 +91,7 @@ class WorkerInterceptorTest {
 
                     }
 
-            assertEquals(1, worker.getInterceptors().size)
+            assertEquals(1, worker.getInterceptors().size())
         }
     }
 
@@ -112,7 +112,7 @@ class WorkerInterceptorTest {
 
                     }
 
-            assertEquals(2, worker.getInterceptors().size)
+            assertEquals(2, worker.getInterceptors().size())
         }
     }
 


### PR DESCRIPTION
At setup phase of WorkerInterceptors, they are stored in a list, even tough they
are by them self a linked list. Now this is utilized from start, which means that we
can use copy-on-write when we modify this list, and get rid of the mutability of this
list that caused a race condition. This is an alternate solution on the NPE that @bonahona
has adressed in pull request #34.